### PR TITLE
Prompt user for intranet username on first run

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,8 +12,10 @@ const os = require('os')
 window.isLinux = os.platform() === 'linux'
 
 if (!localStorage.getItem('username')) {
-  // get username from system
-  const username = os.userInfo().username
+  const defaultUsername = os.userInfo().username
+  const promptText = "Entrez s'il vous plaît votre Pseudo de la JVLAN (Pseudo Intranet)"
+  const username =
+    window.prompt(promptText, defaultUsername)?.trim() || defaultUsername
   localStorage.setItem('username', username)
 }
 if (!localStorage.getItem('gameVersion')) localStorage.setItem('gameVersion', '1')


### PR DESCRIPTION
## Summary
- prompt for a username when launching the app for the first time
  - default to the system username

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run typecheck` *(fails: missing tsconfig dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688142a060808325b698ff9bc2dbaa08