### PR TITLE
Add username prompt on first launch

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     version: string
     isLinux: boolean
+    getSystemUsername: () => string
     electron: typeof electron
     getCurrentWindow: () => Electron.BrowserWindow
     openMenu: (x: number, y: number) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,10 +11,9 @@ const os = require('os')
 // @ts-ignore (define in dts)
 window.isLinux = os.platform() === 'linux'
 
-if (!localStorage.getItem('username')) {
-  // get username from system
-  const username = os.userInfo().username
-  localStorage.setItem('username', username)
+// @ts-ignore (define in dts)
+window.getSystemUsername = (): string => {
+  return os.userInfo().username
 }
 if (!localStorage.getItem('gameVersion')) localStorage.setItem('gameVersion', '1')
 if (!localStorage.getItem('language')) localStorage.setItem('language', 'en')

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -16,6 +16,8 @@ import Playtime from './components/Playtime'
 // states
 import { useGameState } from './states/gameState'
 import { useSelectedServerState } from './states/selectedServerState'
+import { useAuthState } from './states/authState'
+import { useUIState } from './states/uiState'
 
 // Images
 import LogoImage from './images/logo.png'
@@ -39,6 +41,8 @@ function App(): JSX.Element {
 
   const { fetchPublicServers } = useGameState()
   const { currServer, currServerName, currServerType } = useSelectedServerState()
+  const { setUsername } = useAuthState()
+  const { setPopUpState } = useUIState()
 
   useEffect(() => {
     axios.get('https://cdn.kocity.xyz/launcher/assets/options.json').then((res) => {
@@ -97,6 +101,16 @@ function App(): JSX.Element {
   useEffect(() => {
     setInterval(fetchPublicServers, 1000 * 60 * 3)
     fetchPublicServers()
+  }, [])
+
+  useEffect(() => {
+    if (!localStorage.getItem('username')) {
+      const defaultName = window.getSystemUsername()
+      setUsername(defaultName)
+      const field = document.getElementById('usernameField') as HTMLInputElement
+      if (field) field.value = defaultName
+      setPopUpState('usernamePrompt')
+    }
   }, [])
 
   return (

--- a/src/renderer/src/components/popUp/index.tsx
+++ b/src/renderer/src/components/popUp/index.tsx
@@ -263,6 +263,72 @@ function PopUp(): JSX.Element {
           </Box>
         </Backdrop>
       )
+    case 'usernamePrompt':
+      return (
+        <Backdrop open={true} style={{ zIndex: 1000 }}>
+          <Box
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              backgroundColor: '#1a1a1a',
+              width: '600px',
+              height: '250px',
+              borderRadius: '5px',
+              padding: '10px',
+              textAlign: 'center'
+            }}
+          >
+            <Typography
+              variant="h4"
+              style={{
+                color: 'white',
+                textAlign: 'center',
+                marginTop: '20px',
+                fontFamily: 'Brda',
+                fontStyle: 'italic',
+                letterSpacing: '2px'
+              }}
+            >
+              Username
+            </Typography>
+            <p>Entrez s'il vous plaît votre Pseudo de la JVLAN (Pseudo Intranet)</p>
+            <Input
+              id="usernamePromptInput"
+              sx={{ input: { textAlign: 'center' } }}
+              type="text"
+              placeholder="Username"
+              defaultValue={window.getSystemUsername()}
+              style={{ width: '200px', textAlign: 'center', fontSize: '20px' }}
+              onChange={(event): void => {
+                if (event.target.value.length > 16)
+                  event.target.value = event.target.value.slice(0, 16)
+              }}
+            />
+            <Stack direction="row" spacing={2}>
+              <Button
+                variant="contained"
+                className="hoverButton"
+                onClick={(): void => {
+                  const value = (
+                    document.getElementById('usernamePromptInput') as HTMLInputElement
+                  ).value.trim()
+                  if (value) {
+                    setUsername(value)
+                    localStorage.setItem('username', value)
+                    const field = document.getElementById('usernameField') as HTMLInputElement
+                    if (field) field.value = value
+                    setPopUpState(false)
+                  }
+                }}
+                style={{ marginTop: '10px' }}
+              >
+                Save
+              </Button>
+            </Stack>
+          </Box>
+        </Backdrop>
+      )
     case 'confirmLogout':
       return <ConfirmLogout />
     case 'authenticating':


### PR DESCRIPTION
## Summary
- expose a `getSystemUsername` helper in preload
- add new `usernamePrompt` popup for first run
- prompt for username on app load when none saved

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run typecheck` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_688142a060808325b698ff9bc2dbaa08